### PR TITLE
make google api requests concurrent

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     </div>
 
     <script src="https://apis.google.com/js/platform.js"></script>
+    <script src="https://unpkg.com/semaphore@1.1.0/lib/semaphore.js"></script>
     <script type="module" src="main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR introduces a semaphore to be used when hitting the google photos API and will limit concurrent requests to 3. The [API reference](https://developers.google.com/photos/library/guides/api-limits-quotas) doesn't explicitly state what the concurrent limits are but I didn't hit any during my testing. 