### PR TITLE
Migrate to Google Identity Services

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,64 +1,44 @@
 import jwtHelper from './helpers/jwt-helper.js';
 
-let _signinCallback = (userDisplay) => { console.warning('signinCallback not provided', userDisplay); };
-
-function signInSuccessForCurrentUser(googleAuth) {
-  return signInSuccess(googleAuth.currentUser.get());
-}
-function signInSuccess(googleUser) {
-  alert('sign in success called');
-
-  if (!googleUser)
-    return signInFailure('gapi.signInSuccess:no-user');
-
-  let userEmail = googleUser.getBasicProfile().getEmail();
-  _signinCallback(userEmail || 'Signed In'); // If no 'email' scope was requested then no email will be available.
-}
-function signInFailure(err) {
-  console.error('gapi.signInFailure', err);
-  _signinCallback(`error:${JSON.stringify(err)}`);
+async function loadAccessToken(gapi_client_id, gapi_scopes) {
+  await new Promise((resolve, reject) => {
+    try {
+      // Settle this promise in the response callback for requestAccessToken()
+      const tokenClient = google.accounts.oauth2.initTokenClient({
+        client_id: gapi_client_id,
+        scope: gapi_scopes,
+        prompt: 'none',
+        callback: (resp) => {
+          if (resp.error !== undefined) {
+            reject(resp);
+          }
+          window.access_token = resp.access_token;
+          resolve(resp);
+        }
+      });
+      tokenClient.requestAccessToken();
+    } catch (err) {
+      console.log(err)
+    }
+  });
 }
 
 export default {
 
   async init(gapi_client_id, gapi_scopes, signinCallback) {
-
     await gisLoadPromise;
-
     google.accounts.id.initialize({
       client_id: gapi_client_id,
       callback: async (response) => {
         const decodedCredential = jwtHelper.parseJwt(response.credential);
         signinCallback(decodedCredential.name);
-        await this.loadAccessToken(gapi_client_id, gapi_scopes);
-      }
-    });
-  },
-
-  async loadAccessToken(gapi_client_id, gapi_scopes) {
-    await new Promise((resolve, reject) => {
-      try {
-        // Settle this promise in the response callback for requestAccessToken()
-        const tokenClient = google.accounts.oauth2.initTokenClient({
-          client_id: gapi_client_id,
-          scope: gapi_scopes,
-          prompt: 'none',
-          callback: (resp) => {
-            if (resp.error !== undefined) {
-              reject(resp);
-            }
-            window.access_token = resp.access_token;
-            resolve(resp);
-          }
-        });
-        tokenClient.requestAccessToken();
-      } catch (err) {
-        console.log(err)
+        await loadAccessToken(gapi_client_id, gapi_scopes);
       }
     });
   },
 
   renderButton(buttonContainerId, gapi_scopes) {
+    // https://developers.google.com/identity/gsi/web/guides/display-button#javascript
     google.accounts.id.renderButton(
       document.getElementById(buttonContainerId),
       { theme: "outline", size: "large" }

--- a/helpers/google-photos.js
+++ b/helpers/google-photos.js
@@ -1,11 +1,14 @@
 const ENDPOINT = 'https://photoslibrary.googleapis.com/v1';
 
-function getAccessToken(gapi) {
-	return window.gapi
-		.auth2.getAuthInstance()
-		.currentUser.get()
-		.getAuthResponse(true)
-		.access_token;
+function getAccessToken() {
+	/**
+	 * The new Google Identity Service's (GIS) TokenClient.requestAccessToken() method displays a popup when invoked.
+	 * Since we are using the access token in a loop, it is less than ideal to get the token (and hence, show the popup) on each iteration.
+	 * To address, move the access token fetcher to init.js and save in a global variable (ugh!).
+	 * If we were using GAPI client, GIS would automatically set the client's token.
+	 */
+
+	return window.access_token;
 }
 
 function doRequest(method, path, body, accessToken) {
@@ -18,11 +21,11 @@ function doRequest(method, path, body, accessToken) {
 		},
 		body: body ? JSON.stringify(body) : undefined
 	})
-	.then(response => response.json());
+		.then(response => response.json());
 }
 
 export default {
-	request: (method, path, body) => {
+	request: async (method, path, body) => {
 		return doRequest(method, path, method !== 'GET' ? body : undefined, getAccessToken());
 	}
 }

--- a/helpers/jwt-helper.js
+++ b/helpers/jwt-helper.js
@@ -1,0 +1,16 @@
+// https://www.codegrepper.com/code-examples/javascript/how+to+decode+jwt+token+in+javascript+without+using+a+library
+
+let b64DecodeUnicode = str =>
+    decodeURIComponent(
+        Array.prototype.map.call(atob(str), c =>
+            '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+        ).join(''))
+
+export default {
+    parseJwt: (token) =>
+        JSON.parse(
+            b64DecodeUnicode(
+                token.split('.')[1].replace('-', '+').replace('_', '/')
+            )
+        )
+}

--- a/index.html
+++ b/index.html
@@ -43,7 +43,17 @@
     <div id="cardResults" class="card" hidden>
     </div>
 
-    <script src="https://apis.google.com/js/platform.js"></script>
+    <!-- https://developers.google.com/identity/oauth2/web/guides/migration-to-gis#gapi-asyncawait -->
+    <script>
+      const gisLoadPromise = new Promise((resolve, reject) => {
+      gisLoadOkay = resolve;
+      gisLoadFail = reject;
+    });
+    </script>
+    <script async defer src="https://accounts.google.com/gsi/client" onload="gisLoadOkay()" onerror="gisLoadFail(event)"></script>
     <script type="module" src="main.js"></script>
+    <script>
+      document.cookie = "G_AUTH2_MIGRATION=informational";
+    </script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -12,9 +12,9 @@ ui.elements.buttonRunCommand.addEventListener('click', () => runCommand(commands
 
 const gapiScopes = distillCommandScopes(commands);
 // Initialize the UI and then initialize Auth (with gapi & scopes).
-ui.init((gapiClientId) => {
+ui.init(async (gapiClientId) => {
   if (gapiClientId) {
-    auth.init(gapiClientId, gapiScopes, (userDisplayIdentity) => { ui.state.identity = userDisplayIdentity; });
+    await auth.init(gapiClientId, gapiScopes, (userDisplayIdentity) => { ui.state.identity = userDisplayIdentity; });    
     auth.renderButton(ui.elements.containerSigninButton.id, gapiScopes);
   }
 });
@@ -29,7 +29,7 @@ async function runCommand(selectedCommand) {
   ui.state.running = true;
 
   try {
-    ui.state.results = await selectedCommand.run(gapi); // gapi should already be loaded globally
+    ui.state.results = await selectedCommand.run();
   }
   catch (err) {
     throw err;


### PR DESCRIPTION
As per notice in the [migration guide](https://developers.google.com/identity/oauth2/web/guides/migration-to-gis), Google has deprecated the [Google Sign-In Platform Library](https://developers.google.com/identity/sign-in/web/sign-in). This pull request migrates to the newer [Google Identity Services](https://developers.google.com/identity/oauth2/web/guides/overview). As a side-effect, it also gets rid of the ["popup_closed_by_user" error](https://github.com/jonagh/gapi-querier/issues/4) in cases where popups are already enabled yet this error pops up.